### PR TITLE
Normalize the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository provides metapackages for pip and conda that centralize the Dask version dependency across RAPIDS.
 Dask's API instability means that each RAPIDS release must pin to a very specific Dask release to avoid incompatibilities.
 These metapackages provide a centralized, versioned storehouse for that pinning.
-The `rapids_dask_dependency` package encodes both `dask` and `distributed` requirements.
+The `rapids-dask-dependency` package encodes both `dask` and `distributed` requirements.
 
 # Metapackage Versioning
 

--- a/conda/recipes/rapids_dask_dependency/meta.yaml
+++ b/conda/recipes/rapids_dask_dependency/meta.yaml
@@ -3,7 +3,7 @@
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 
 package:
-  name: rapids_dask_dependency
+  name: rapids-dask-dependency
   version: {{ version }}
 
 source:

--- a/pip/rapids_dask_dependency/pyproject.toml
+++ b/pip/rapids_dask_dependency/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 ]
 
 [project]
-name = "rapids_dask_dependency"
+name = "rapids-dask-dependency"
 version = "23.12.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [


### PR DESCRIPTION
As per [PEP 503](https://peps.python.org/pep-0503/#normalized-names), packages uploaded to PyPI-like "simple" repositories will have their names normalized, and in particular underscores are replaced with hyphens. Although `pip install` command will perform the same normalization and therefore support both characters in the command, hyphens have become the more familiar naming choice as a result. This PR standardizes the names for pip and conda to alleviate any confusion.