### PR TITLE
Unpin `dask` and `distributed` for `24.02` development

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -15,9 +15,9 @@ build:
 
 requirements:
   run:
-    - dask ==2023.11.0
-    - dask-core ==2023.11.0
-    - distributed ==2023.11.0
+    - dask >=2023.11.0
+    - dask-core >=2023.11.0
+    - distributed >=2023.11.0
 
 about:
   home: https://rapids.ai/

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "24.02.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2023.11.0",
-    "distributed==2023.11.0",
+    "dask @ git+https://github.com/dask/dask.git@main",
+    "distributed @ git+https://github.com/dask/distributed.git@main",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This PR unpins `dask` and `distributed` for `24.02` development.