### PR TITLE
Add license and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,35 +5,29 @@ Dask's API instability means that each RAPIDS release must pin to a very specifi
 These metapackages provide a centralized, versioned storehouse for that pinning.
 The `rapids-dask-dependency` package encodes both `dask` and `distributed` requirements.
 
-# Metapackage Versioning
+# Versioning the Metapackage Itself
 
-During the development cycle for RAPIDS, this metapackage will be released as an alpha-versioned package, e.g. `23.10.00a0`.
+This package is versioned just like the rest of RAPIDS: using CalVer, with alpha tags (trailing a\*) for nightlies.
+Nightlies of the metapackage should be consumed just like nightlies of any other RAPIDS package: 
+  - conda packages should pin up to the minor version with a trailing `.*`, i.e. `==23.10.*`. Conda will allow nightlies to match, so no further intervention is needed.
+  - pip packages should have the same pin, but wheel building scripts must add an alpha spec `>=0.0.0a0` when building nightlies to allow rapids-dask-dependency nightlies. This is the same strategy used to have RAPIDS repositories pull nightly versions of other RAPIDS dependencies (e.g. `cudf` requires `rmm` nightlies).
 
-For conda packages, RAPIDS repos will only pin up to the RAPIDS patch version, i.e. `==23.10.00.*`.
-When RAPIDS hits code freeze and we pin Dask versions, the package versions in this repository should be pinned.
-At this time, a non-alpha release of the metapackage will be created, `23.10.00`.
-This new metapackage version will be automatically picked up by other RAPIDS libraries since they will be using a `==23.10.00.*` pin.
+# Strategy for Dask Nightlies
 
-For pip wheels, RAPIDS repos will need to set up their wheel building scripts to add an alpha spec `>=0.0.0a0` to the Dask dependencies in `pyproject.toml`.
-The alpha spec addition should be conditional on whether the package is being built as a nightly or a release.
-That will ensure that upon release of rapids-dask-dependency the correct version will be picked up.
-This is the same strategy used to have RAPIDS repositories pull nightly versions of other RAPIDS dependencies (e.g. `cudf` requires `rmm` nightlies).
-
-# Requiring Dask nightlies
-
-During RAPIDS development phase, Dask versions should be specified using PEP 440-compatible versions like `>=2023.7.1a0` so that nightlies may be picked up.
 For conda, nightlies are published to the [dask channel](https://anaconda.org/dask/).
 The metapackage assumes that the `dask/label/dev` channel is included in a user's condarc so that the nightly will be found.
-For pip, no nightlies are published so the packages must be installed directly from source.
-To do so, the metapackage will encode dependencies as:
+During RAPIDS development phase, Dask versions should be specified using PEP 440-compatible versions like `>=2023.7.1a0` so that nightlies may be picked up.
+Then, at release time these versions may be pinned.
+
+
+For pip, dask and distributed do not publish nightly wheels.
+Therefore, the only option is for this metapackage to install those dependencies from source.
+To do so, the metapackage will encode dependencies in pyproject.toml as:
 ```
 - dask @ git+https://github.com/dask/dask.git@main
 - distributed @ git+https://github.com/dask/distributed.git@main
 ```
-
-# RAPIDS patch releases
-
-If RAPIDS itself requires a patch release, a new metapackage version will be released that bumps the patch version e.g. `23.10.01a0`.
-RAPIDS libraries should at this time update their metapackage pinnings to be `==23.10.01.*` so that metapackages corresponding to the patch release are detected.
-Note that patch releases are why we must specify `==` rather than `>=` constraints.
-We do not want a new metapackage release for a RAPIDS patch release to affect lower patch releases, because a patch release of RAPIDS could involve Dask changes, necessitating a bump in the Dask pinning that we do not want to propagate backwards to the previous patch release.
+At release, these dependencies will be pinned to the desired versions.
+Note that encoding direct URLs as above is technically prohibited by the [Python packaging specifications](https://packaging.python.org/en/latest/specifications/version-specifiers/#direct-references).
+However, while PyPI enforces this, the RAPIDS nightly index does not.
+Therefore, use of this versioning strategy currently prohibits rapids-dask-dependency nightlies from being uploaded to PyPI, and they must be hosted on the RAPIDS nightly pip index.

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "dask==2023.11.0",
     "distributed==2023.11.0",
 ]
+license = { text = "Apache 2.0" }
 
 [tool.setuptools]
 license-files = ["LICENSE"]


### PR DESCRIPTION
The license field was missing from pyproject.toml, and the README documented an outdated versioning strategy that changed once we actually started using the metapackage in other RAPIDS packages.

Replaces #11
