### PR TITLE
Pin Distributed to last working version

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   run:
     - dask >=2023.11.0
     - dask-core >=2023.11.0
-    - distributed >=2023.11.0
+    - distributed >=2023.11.0,<2023.12.2a240110
 
 about:
   home: https://rapids.ai/

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -13,7 +13,7 @@ version = "24.02.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
     "dask @ git+https://github.com/dask/dask.git@main",
-    "distributed @ git+https://github.com/dask/distributed.git@main",
+    "distributed @ git+https://github.com/dask/distributed.git@7562f9c566978de4f3f5b73920a24ea1813d6e28",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
To workaround issue ( https://github.com/dask/distributed/issues/8454 ), pin Distributed to a version before PR ( https://github.com/dask/distributed/pull/8443 ) was included