### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -15,9 +15,9 @@ build:
 
 requirements:
   run:
-    - dask >=2023.11.0
-    - dask-core >=2023.11.0
-    - distributed >=2023.11.0
+    - dask ==2024.1.1
+    - dask-core ==2024.1.1
+    - distributed ==2024.1.1
 
 about:
   home: https://rapids.ai/

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "24.02.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask @ git+https://github.com/dask/dask.git@main",
-    "distributed @ git+https://github.com/dask/distributed.git@main",
+    "dask==2024.1.1",
+    "distributed==2024.1.1",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.