### PR TITLE
Unpin dask and distributed for `24.04` development

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -15,9 +15,9 @@ build:
 
 requirements:
   run:
-    - dask ==2024.1.1
-    - dask-core ==2024.1.1
-    - distributed ==2024.1.1
+    - dask >=2024.1.1
+    - dask-core >=2024.1.1
+    - distributed >=2024.1.1
 
 about:
   home: https://rapids.ai/

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "24.04.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2024.1.1",
-    "distributed==2024.1.1",
+    "dask @ git+https://github.com/dask/dask.git@main",
+    "distributed @ git+https://github.com/dask/distributed.git@main",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
This PR unpins dask and distributed for `24.04` development.