### PR TITLE
update CI matrix selectors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,8 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and .CUDA_VER == "12.0.1"))
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
   upload-conda:
     needs: python-build
     secrets: inherit
@@ -55,7 +56,8 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and .CUDA_VER == "12.0.1"))
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,12 +22,14 @@ jobs:
     with:
       build_type: pull-request
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and .CUDA_VER == "12.0.1"))
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
   wheel-build:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.04
     with:
       build_type: pull-request
       # Package is pure Python and only ever requires one build.
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and .CUDA_VER == "12.0.1"))
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/25.
Contributes to https://github.com/rapidsai/build-planning/issues/3.

This project uses a `jq` filter in its GitHub Actions configuration to select exactly 1 combination of `(architecture, Python version, CUDA version)` for each of its CI jobs.

This PR proposes removing string literals referencing specific versions, so that the configuration won't have to be updated in the future as RAPIDS changes its supported matrix of Python and CUDA versions.

Credit for this to @bdice / @ajschmidt8 : https://github.com/rapidsai/build-planning/issues/25#issuecomment-1970077254. I'm just clicking the buttons 😁 