### PR TITLE
Pin before loud ``dask.dataframe`` deprecation warning

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -15,9 +15,10 @@ build:
 
 requirements:
   run:
-    - dask >=2024.1.1
-    - dask-core >=2024.1.1
-    - distributed >=2024.1.1
+    - dask ==2024.1.1
+    - dask-core ==2024.1.1
+    - distributed ==2024.1.1
+    - dask_expr ==0.4.0
 
 about:
   home: https://rapids.ai/

--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - dask ==2024.1.1
     - dask-core ==2024.1.1
     - distributed ==2024.1.1
-    - dask_expr ==0.4.0
+    - dask-expr ==0.4.0
 
 about:
   home: https://rapids.ai/

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -12,8 +12,9 @@ name = "rapids-dask-dependency"
 version = "24.04.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask @ git+https://github.com/dask/dask.git@main",
-    "distributed @ git+https://github.com/dask/distributed.git@main",
+    "dask==2024.1.1",
+    "distributed==2024.1.1",
+    "dask_expr==0.4.0",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/pip/rapids-dask-dependency/pyproject.toml
+++ b/pip/rapids-dask-dependency/pyproject.toml
@@ -14,7 +14,7 @@ description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
     "dask==2024.1.1",
     "distributed==2024.1.1",
-    "dask_expr==0.4.0",
+    "dask-expr==0.4.0",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
- This rolls back the changes in https://github.com/rapidsai/rapids-dask-dependency/pull/25 until we have a plan to deal with the loud `dask.dataframe` deprecation warning in `dask>=2024.2.0`
- This adds `dask_expr` as a dependency in preparation for https://github.com/rapidsai/cudf/pull/14805 (happy to add this in a follow-up PR if others prefer)
- We may be able to remove the pin for 24.04 if/when https://github.com/rapidsai/rapids-dask-dependency/pull/27 is merged (fingers crossed). However, the *default* plan is still to keep the 2024.1.1 dask pin in place until 24.06 (see: https://github.com/rapidsai/rapids-dask-dependency/issues/26)