### PR TITLE
Treat rapids-dask-dependency CI artifacts as pure wheels

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -15,4 +15,4 @@ sed -i "s/^version = .*/version = \"${version}\"/g" "${package_dir}/pyproject.to
 cd "${package_dir}"
 python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
-RAPIDS_PY_WHEEL_NAME="${package_name}" rapids-upload-wheels-to-s3 dist
+RAPIDS_PY_WHEEL_NAME="${package_name}" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist


### PR DESCRIPTION
## Description
This marks `rapids-dask-dependency` as a pure wheel, meaning that the CI artifacts are not specific to a Python version or CPU architecture. This change depends on https://github.com/rapidsai/gha-tools/pull/96, and makes CI workflows more robust by allowing the test matrix to be separated from the build matrix.
