### PR TITLE
Use `noarch: python`

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -11,10 +11,13 @@ source:
 
 build:
   number: 0
-  noarch: generic
+  noarch: python
 
 requirements:
+  host:
+    - python
   run:
+    - python
     - dask ==2024.1.1
     - dask-core ==2024.1.1
     - distributed ==2024.1.1


### PR DESCRIPTION
As this is become a proper Python package, convert it to `noarch: python` instead of `noarch: generic`.