### PR TITLE
Temporarily override the query-planning default

### DIFF
--- a/rapids_dask_dependency/patches/dask/__init__.py
+++ b/rapids_dask_dependency/patches/dask/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 from .add_patch_attr import add_patch_attr
+from .config_defaults import set_config_defaults
 
-patches = [add_patch_attr]
+patches = [add_patch_attr, set_config_defaults]

--- a/rapids_dask_dependency/patches/dask/config_defaults.py
+++ b/rapids_dask_dependency/patches/dask/config_defaults.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+
+def set_config_defaults(mod):
+    # Set "dataframe.query-planning" default to False
+    if mod.__name__ == "dask":
+        if mod.config.get("dataframe.query-planning", None) is None:
+            mod.config.set({"dataframe.query-planning": False})


### PR DESCRIPTION
Now that we know downstream libraries will likely hit CI problems with "query-planning" turned on. It may make sense to (1) override the default configuration in `rapids-dask-dependency`, and then to (2) open PRs across all down-stream libraries that explicitly opt in to "query-planning" for CI. These test PRs can expose bugs/issues without blocking CI.

The obvious alternative is to explicitly set `DASK_DATAFRAME__QUERY_PLANNING=False` in any down-stream library with failing CI until all issues/bugs have been resolved.