### PR TITLE
Check test exit codes.

### DIFF
--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,13 +1,38 @@
+import contextlib
+import tempfile
 from functools import wraps
 from multiprocessing import Process
 
 
 def run_test_in_subprocess(func):
+    def redirect_stdout_stderr(func, stdout, stderr, *args, **kwargs):
+        with open(stdout, "w") as stdout_file, open(stderr, "w") as stderr_file:
+            with contextlib.redirect_stdout(stdout_file), contextlib.redirect_stderr(
+                stderr_file
+            ):
+                func(*args, **kwargs)
+
     @wraps(func)
     def wrapper(*args, **kwargs):
-        p = Process(target=func, args=args, kwargs=kwargs)
-        p.start()
-        p.join()
+        with tempfile.NamedTemporaryFile(
+            mode="w+"
+        ) as stdout, tempfile.NamedTemporaryFile(mode="w+") as stderr:
+            p = Process(
+                target=redirect_stdout_stderr,
+                args=(func, stdout.name, stderr.name, *args),
+                kwargs=kwargs,
+            )
+            p.start()
+            p.join()
+            stdout_log = stdout.file.read()
+            stderr_log = stderr.file.read()
+        if p.exitcode != 0:
+            msg = f"Process exited {p.exitcode}."
+            if stdout_log:
+                msg += f"\nstdout:\n{stdout_log}"
+            if stderr_log:
+                msg += f"\nstderr:\n{stderr_log}"
+            raise RuntimeError(msg)
 
     return wrapper
 


### PR DESCRIPTION
Currently, the tests added in #27 (backported to 24.04 in #36) do not check the exit codes of their subprocesses. This means that failing tests are not caught. This PR fixes the test utilities to check the exit codes and print any stdout/stderr outputs.
