### PR TITLE
Generalize patching to support vendoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
+# Always exclude vendored files from linting
+exclude: ".*__rdd_patch_.*"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/rapids_dask_dependency/dask_loader.py
+++ b/rapids_dask_dependency/dask_loader.py
@@ -4,7 +4,6 @@ import importlib
 import importlib.abc
 import importlib.machinery
 import importlib.util
-import os
 import sys
 from contextlib import contextmanager
 
@@ -22,16 +21,18 @@ class DaskLoader(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         if spec.name.startswith("dask") or spec.name.startswith("distributed"):
             with self.disable():
                 try:
-                    proxy = importlib.import_module(f"rapids_dask_dependency.patches.{spec.name}")
+                    proxy = importlib.import_module(
+                        f"rapids_dask_dependency.patches.{spec.name}"
+                    )
                     # TODO: The warning filter will no longer work for this one, we'll
                     # have to increase the stacklevel further.
                     mod = proxy.load_module(spec)
 
                 except ModuleNotFoundError:
                     # Add 3 to the stacklevel to account for the 3 extra frames added by
-                    # the loader: one in the produced warnings function, one in the actual
-                    # loader, and one in the importlib call (not including all internal
-                    # frames).
+                    # the loader: one in the produced warnings function, one in the
+                    # actual loader, and one in the importlib call (not including all
+                    # internal frames).
                     with patch_warning_stacklevel(3):
                         mod = importlib.import_module(spec.name)
 

--- a/rapids_dask_dependency/dask_loader.py
+++ b/rapids_dask_dependency/dask_loader.py
@@ -11,12 +11,6 @@ from rapids_dask_dependency.utils import patch_warning_stacklevel, update_spec
 
 
 class DaskLoader(importlib.abc.MetaPathFinder, importlib.abc.Loader):
-    def __init__(self):
-        # On creation and before this object is added to the meta path, cache the
-        # location to the real dask if it exists so that we can use it to spoof the
-        # origin of modules that we vendor instead of patching.
-        self.real_dask_spec = importlib.util.find_spec("dask")
-
     def create_module(self, spec):
         if spec.name.startswith("dask") or spec.name.startswith("distributed"):
             with self.disable():

--- a/rapids_dask_dependency/dask_loader.py
+++ b/rapids_dask_dependency/dask_loader.py
@@ -4,28 +4,9 @@ import importlib
 import importlib.abc
 import importlib.machinery
 import sys
-import warnings
 from contextlib import contextmanager
-from functools import lru_cache
 
-original_warn = warnings.warn
-
-
-@lru_cache()
-def _make_warning_func(level):
-    def _warning_with_increased_stacklevel(
-        message, category=None, stacklevel=1, source=None, **kwargs
-    ):
-        # Patch warnings to have the right stacklevel
-        original_warn(message, category, stacklevel + level, source, **kwargs)
-    return _warning_with_increased_stacklevel
-
-
-@contextmanager
-def patch_warning_stacklevel(level):
-    warnings.warn = _make_warning_func(level)
-    yield
-    warnings.warn = original_warn
+from rapids_dask_dependency.utils import patch_warning_stacklevel
 
 
 class DaskLoader(importlib.abc.MetaPathFinder, importlib.abc.Loader):

--- a/rapids_dask_dependency/dask_loader.py
+++ b/rapids_dask_dependency/dask_loader.py
@@ -35,7 +35,7 @@ class DaskLoader(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                 with patch_warning_stacklevel(3):
                     mod = importlib.import_module(spec.name)
 
-                update_spec(spec, mod)
+                update_spec(spec, mod.__spec__)
                 return mod
 
     def exec_module(self, _):

--- a/rapids_dask_dependency/importer.py
+++ b/rapids_dask_dependency/importer.py
@@ -1,11 +1,19 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import importlib
+from abc import abstractmethod
 
 from rapids_dask_dependency.utils import patch_warning_stacklevel, update_spec
 
 
-class MonkeyPatchImporter:
+class BaseImporter:
+    @abstractmethod
+    def load_module(self, spec):
+        pass
+
+
+# TODO: Support an actual patch function.
+class MonkeyPatchImporter(BaseImporter):
     """The base importer for modules that are monkey-patched."""
 
     def __init__(self, name):
@@ -21,3 +29,24 @@ class MonkeyPatchImporter:
         update_spec(spec, mod)
         mod._rapids_patched = True
         return mod
+
+
+class VendoredImporter(BaseImporter):
+    """The base importer for vendored modules."""
+
+    # Vendored files use a standard prefix to avoid name collisions.
+    default_prefix = "__rdd_patch_"
+
+    def __init__(self, module):
+        self.real_module = module
+        module_parts = module.split(".")
+        module_parts[-1] = self.default_prefix + module_parts[-1]
+        self.vendored_module = ".".join(module_parts)
+
+    def load_module(self, spec):
+        vendored_module = importlib.import_module(
+            f"rapids_dask_dependency.patches.{self.vendored_module}"
+        )
+        # TODO: Need a way to get this cleanly when the loader is already installed.
+        # update_spec(spec, mod)
+        return vendored_module

--- a/rapids_dask_dependency/importer.py
+++ b/rapids_dask_dependency/importer.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import importlib
+
+from rapids_dask_dependency.utils import patch_warning_stacklevel, update_spec
+
+
+class MonkeyPatchImporter:
+    """The base importer for modules that are monkey-patched."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def load_module(self, spec):
+        # Four extra stack frames: 1) DaskLoader.create_module, 2)
+        # MonkeyPatchImporter.load_module, 3) importlib.import_module, and 4) the
+        # patched warnings function (not including the internal frames, which warnings
+        # ignores).
+        with patch_warning_stacklevel(4):
+            mod = importlib.import_module(self.name)
+        update_spec(spec, mod)
+        mod._rapids_patched = True
+        return mod

--- a/rapids_dask_dependency/patches/dask/__init__.py
+++ b/rapids_dask_dependency/patches/dask/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import importlib
+
 from rapids_dask_dependency.utils import update_spec
 
 

--- a/rapids_dask_dependency/patches/dask/__init__.py
+++ b/rapids_dask_dependency/patches/dask/__init__.py
@@ -1,12 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
-import importlib
+from rapids_dask_dependency.importer import MonkeyPatchImporter
 
-from rapids_dask_dependency.utils import update_spec
-
-
-def load_module(spec):
-    mod = importlib.import_module("dask")
-    update_spec(spec, mod)
-    mod._rapids_patched = True
-    return mod
+_importer = MonkeyPatchImporter("dask")
+load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/dask/__init__.py
+++ b/rapids_dask_dependency/patches/dask/__init__.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
-from .add_patch_attr import add_patch_attr
+import importlib
 
-patches = [add_patch_attr]
+
+def load_module():
+    mod = importlib.import_module("dask")
+    mod._rapids_patched = True
+    return mod

--- a/rapids_dask_dependency/patches/dask/__init__.py
+++ b/rapids_dask_dependency/patches/dask/__init__.py
@@ -2,5 +2,5 @@
 
 from rapids_dask_dependency.importer import MonkeyPatchImporter
 
-_importer = MonkeyPatchImporter("dask")
+_importer = MonkeyPatchImporter(__name__, lambda _: None)
 load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/dask/__init__.py
+++ b/rapids_dask_dependency/patches/dask/__init__.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import importlib
+from rapids_dask_dependency.utils import update_spec
 
 
-def load_module():
+def load_module(spec):
     mod = importlib.import_module("dask")
+    update_spec(spec, mod)
     mod._rapids_patched = True
     return mod

--- a/rapids_dask_dependency/patches/dask/add_patch_attr.py
+++ b/rapids_dask_dependency/patches/dask/add_patch_attr.py
@@ -1,5 +1,0 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
-
-
-def add_patch_attr(mod):
-    mod._rapids_patched = True

--- a/rapids_dask_dependency/patches/dask/dataframe/__rdd_patch_accessor.py
+++ b/rapids_dask_dependency/patches/dask/dataframe/__rdd_patch_accessor.py
@@ -35,7 +35,7 @@ def _bind_property(cls, pd_cls, attr, min_version=None):
     elif isinstance(original_prop, functools.cached_property):
         method = original_prop.func
     else:
-        raise TypeError("bind_property expects original class to provide a property")
+        method = original_prop
     try:
         func.__wrapped__ = method
     except Exception:

--- a/rapids_dask_dependency/patches/dask/dataframe/__rdd_patch_accessor.py
+++ b/rapids_dask_dependency/patches/dask/dataframe/__rdd_patch_accessor.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import functools
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from dask.dataframe._compat import check_to_pydatetime_deprecation
+from dask.utils import derived_from
+
+
+def _bind_method(cls, pd_cls, attr, min_version=None):
+    def func(self, *args, **kwargs):
+        return self._function_map(attr, *args, **kwargs)
+
+    func.__name__ = attr
+    func.__qualname__ = f"{cls.__name__}.{attr}"
+    try:
+        func.__wrapped__ = getattr(pd_cls, attr)
+    except Exception:
+        pass
+    setattr(cls, attr, derived_from(pd_cls, version=min_version)(func))
+
+
+def _bind_property(cls, pd_cls, attr, min_version=None):
+    def func(self):
+        return self._property_map(attr)
+
+    func.__name__ = attr
+    func.__qualname__ = f"{cls.__name__}.{attr}"
+    original_prop = getattr(pd_cls, attr)
+    if isinstance(original_prop, property):
+        method = original_prop.fget
+    elif isinstance(original_prop, functools.cached_property):
+        method = original_prop.func
+    else:
+        raise TypeError("bind_property expects original class to provide a property")
+    try:
+        func.__wrapped__ = method
+    except Exception:
+        pass
+    setattr(cls, attr, property(derived_from(pd_cls, version=min_version)(func)))
+
+
+def maybe_wrap_pandas(obj, x):
+    if isinstance(x, np.ndarray):
+        if isinstance(obj, pd.Series):
+            return pd.Series(x, index=obj.index, dtype=x.dtype)
+        return pd.Index(x)
+    return x
+
+
+class Accessor:
+    """
+    Base class for pandas Accessor objects cat, dt, and str.
+
+    Notes
+    -----
+    Subclasses should define ``_accessor_name``, ``_accessor_methods``, and
+    ``_accessor_properties``.
+    """
+
+    def __init__(self, series):
+        from dask.dataframe.core import Series
+
+        if not isinstance(series, Series):
+            raise ValueError("Accessor cannot be initialized")
+
+        series_meta = series._meta
+        if hasattr(series_meta, "to_series"):  # is index-like
+            series_meta = series_meta.to_series()
+        meta = getattr(series_meta, self._accessor_name)
+
+        self._meta = meta
+        self._series = series
+
+    def __init_subclass__(cls, **kwargs):
+        """Bind all auto-generated methods & properties"""
+        super().__init_subclass__(**kwargs)
+        pd_cls = getattr(pd.Series, cls._accessor_name)
+        for item in cls._accessor_methods:
+            attr, min_version = item if isinstance(item, tuple) else (item, None)
+            if not hasattr(cls, attr):
+                _bind_method(cls, pd_cls, attr, min_version)
+        for item in cls._accessor_properties:
+            attr, min_version = item if isinstance(item, tuple) else (item, None)
+            if not hasattr(cls, attr):
+                _bind_property(cls, pd_cls, attr, min_version)
+
+    @staticmethod
+    def _delegate_property(obj, accessor, attr):
+        out = getattr(getattr(obj, accessor, obj), attr)
+        return maybe_wrap_pandas(obj, out)
+
+    @staticmethod
+    def _delegate_method(
+        obj, accessor, attr, args, kwargs, catch_deprecation_warnings: bool = False
+    ):
+        with check_to_pydatetime_deprecation(catch_deprecation_warnings):
+            with warnings.catch_warnings():
+                # Falling back on a non-pyarrow code path which may decrease performance
+                warnings.simplefilter("ignore", pd.errors.PerformanceWarning)
+                out = getattr(getattr(obj, accessor, obj), attr)(*args, **kwargs)
+                return maybe_wrap_pandas(obj, out)
+
+    def _property_map(self, attr):
+        meta = self._delegate_property(self._series._meta, self._accessor_name, attr)
+        token = f"{self._accessor_name}-{attr}"
+        return self._series.map_partitions(
+            self._delegate_property, self._accessor_name, attr, token=token, meta=meta
+        )
+
+    def _function_map(self, attr, *args, **kwargs):
+        if "meta" in kwargs:
+            meta = kwargs.pop("meta")
+        else:
+            meta = self._delegate_method(
+                self._series._meta_nonempty, self._accessor_name, attr, args, kwargs
+            )
+        token = f"{self._accessor_name}-{attr}"
+        return self._series.map_partitions(
+            self._delegate_method,
+            self._accessor_name,
+            attr,
+            args,
+            kwargs,
+            catch_deprecation_warnings=True,
+            meta=meta,
+            token=token,
+        )
+
+
+class DatetimeAccessor(Accessor):
+    """Accessor object for datetimelike properties of the Series values.
+
+    Examples
+    --------
+
+    >>> s.dt.microsecond  # doctest: +SKIP
+    """
+
+    _accessor_name = "dt"
+
+    _accessor_methods = (
+        "asfreq",
+        "ceil",
+        "day_name",
+        "floor",
+        "month_name",
+        "normalize",
+        "round",
+        "strftime",
+        "to_period",
+        "to_pydatetime",
+        "to_pytimedelta",
+        "to_timestamp",
+        "total_seconds",
+        "tz_convert",
+        "tz_localize",
+    )
+
+    _accessor_properties = (
+        "components",
+        "date",
+        "day",
+        "day_of_week",
+        "day_of_year",
+        "dayofweek",
+        "dayofyear",
+        "days",
+        "days_in_month",
+        "daysinmonth",
+        "end_time",
+        "freq",
+        "hour",
+        "is_leap_year",
+        "is_month_end",
+        "is_month_start",
+        "is_quarter_end",
+        "is_quarter_start",
+        "is_year_end",
+        "is_year_start",
+        "microsecond",
+        "microseconds",
+        "minute",
+        "month",
+        "nanosecond",
+        "nanoseconds",
+        "quarter",
+        "qyear",
+        "second",
+        "seconds",
+        "start_time",
+        "time",
+        "timetz",
+        "tz",
+        "week",
+        "weekday",
+        "weekofyear",
+        "year",
+    )
+
+    @derived_from(pd.Series.dt)
+    def isocalendar(self):
+        # Sphinx can't solve types with dask-expr available so define explicitly, see
+        # https://github.com/sphinx-doc/sphinx/issues/4961
+        return self._function_map("isocalendar")
+
+
+class StringAccessor(Accessor):
+    """Accessor object for string properties of the Series values.
+
+    Examples
+    --------
+
+    >>> s.str.lower()  # doctest: +SKIP
+    """
+
+    _accessor_name = "str"
+
+    _accessor_methods = (
+        "capitalize",
+        "casefold",
+        "center",
+        "contains",
+        "count",
+        "decode",
+        "encode",
+        "find",
+        "findall",
+        "fullmatch",
+        "get",
+        "index",
+        "isalnum",
+        "isalpha",
+        "isdecimal",
+        "isdigit",
+        "islower",
+        "isnumeric",
+        "isspace",
+        "istitle",
+        "isupper",
+        "join",
+        "len",
+        "ljust",
+        "lower",
+        "lstrip",
+        "match",
+        "normalize",
+        "pad",
+        "partition",
+        ("removeprefix", "1.4"),
+        ("removesuffix", "1.4"),
+        "repeat",
+        "replace",
+        "rfind",
+        "rindex",
+        "rjust",
+        "rpartition",
+        "rstrip",
+        "slice",
+        "slice_replace",
+        "strip",
+        "swapcase",
+        "title",
+        "translate",
+        "upper",
+        "wrap",
+        "zfill",
+    )
+    _accessor_properties = ()
+
+    def _split(self, method, pat=None, n=-1, expand=False):
+        if expand:
+            if n == -1:
+                raise NotImplementedError(
+                    "To use the expand parameter you must specify the number of "
+                    "expected splits with the n= parameter. Usually n splits "
+                    "result in n+1 output columns."
+                )
+            else:
+                delimiter = " " if pat is None else pat
+                meta = self._series._meta._constructor(
+                    [delimiter.join(["a"] * (n + 1))],
+                    index=self._series._meta_nonempty.iloc[:1].index,
+                )
+                meta = getattr(meta.str, method)(n=n, expand=expand, pat=pat)
+        else:
+            meta = (self._series.name, object)
+        return self._function_map(method, pat=pat, n=n, expand=expand, meta=meta)
+
+    @derived_from(
+        pd.Series.str,
+        inconsistencies="``expand=True`` with unknown ``n`` will raise a ``NotImplementedError``",
+    )
+    def split(self, pat=None, n=-1, expand=False):
+        """Known inconsistencies: ``expand=True`` with unknown ``n`` will raise a ``NotImplementedError``."""
+        return self._split("split", pat=pat, n=n, expand=expand)
+
+    @derived_from(pd.Series.str)
+    def rsplit(self, pat=None, n=-1, expand=False):
+        return self._split("rsplit", pat=pat, n=n, expand=expand)
+
+    @derived_from(pd.Series.str)
+    def cat(self, others=None, sep=None, na_rep=None):
+        from dask.dataframe.core import Index, Series
+
+        if others is None:
+
+            def str_cat_none(x):
+                if isinstance(x, (Series, Index)):
+                    x = x.compute()
+
+                return x.str.cat(sep=sep, na_rep=na_rep)
+
+            return self._series.reduction(chunk=str_cat_none, aggregate=str_cat_none)
+
+        valid_types = (Series, Index, pd.Series, pd.Index)
+        if isinstance(others, valid_types):
+            others = [others]
+        elif not all(isinstance(a, valid_types) for a in others):
+            raise TypeError("others must be Series/Index")
+
+        return self._series.map_partitions(
+            str_cat, *others, sep=sep, na_rep=na_rep, meta=self._series._meta
+        )
+
+    @derived_from(pd.Series.str)
+    def extractall(self, pat, flags=0):
+        return self._series.map_partitions(
+            str_extractall, pat, flags, token="str-extractall"
+        )
+
+    def __getitem__(self, index):
+        return self._series.map_partitions(str_get, index, meta=self._series._meta)
+
+    @derived_from(pd.Series.str)
+    def extract(self, *args, **kwargs):
+        # Sphinx can't solve types with dask-expr available so define explicitly, see
+        # https://github.com/sphinx-doc/sphinx/issues/4961
+        return self._function_map("extract", *args, **kwargs)
+
+    @derived_from(pd.Series.str)
+    def startswith(self, *args, **kwargs):
+        # Sphinx can't solve types with dask-expr available so define explicitly, see
+        # https://github.com/sphinx-doc/sphinx/issues/4961
+        return self._function_map("startswith", *args, **kwargs)
+
+    @derived_from(pd.Series.str)
+    def endswith(self, *args, **kwargs):
+        # Sphinx can't solve types with dask-expr available so define explicitly, see
+        # https://github.com/sphinx-doc/sphinx/issues/4961
+        return self._function_map("endswith", *args, **kwargs)
+
+
+def str_extractall(series, pat, flags):
+    return series.str.extractall(pat, flags=flags)
+
+
+def str_get(series, index):
+    """Implements series.str[index]"""
+    return series.str[index]
+
+
+def str_cat(self, *others, **kwargs):
+    return self.str.cat(others=others, **kwargs)
+
+
+# Ported from pandas
+# https://github.com/pandas-dev/pandas/blob/master/pandas/core/accessor.py
+class CachedAccessor:
+    """
+    Custom property-like object (descriptor) for caching accessors.
+
+    Parameters
+    ----------
+    name : str
+        The namespace this will be accessed under, e.g. ``df.foo``
+    accessor : cls
+        The class with the extension methods. The class' __init__ method
+        should expect one of a ``Series``, ``DataFrame`` or ``Index`` as
+        the single argument ``data``
+    """
+
+    def __init__(self, name, accessor):
+        self._name = name
+        self._accessor = accessor
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            # we're accessing the attribute of the class, i.e., Dataset.geo
+            return self._accessor
+        accessor_obj = self._accessor(obj)
+        # Replace the property with the accessor object. Inspired by:
+        # http://www.pydanny.com/cached-property.html
+        # We need to use object.__setattr__ because we overwrite __setattr__ on
+        # NDFrame
+        object.__setattr__(obj, self._name, accessor_obj)
+        return accessor_obj
+
+
+def _register_accessor(name, cls):
+    def decorator(accessor):
+        if hasattr(cls, name):
+            warnings.warn(
+                "registration of accessor {!r} under name {!r} for type "
+                "{!r} is overriding a preexisting attribute with the same "
+                "name.".format(accessor, name, cls),
+                UserWarning,
+                stacklevel=2,
+            )
+        setattr(cls, name, CachedAccessor(name, accessor))
+        cls._accessors.add(name)
+        return accessor
+
+    return decorator
+
+
+def register_dataframe_accessor(name):
+    """
+    Register a custom accessor on :class:`dask.dataframe.DataFrame`.
+
+    See :func:`pandas.api.extensions.register_dataframe_accessor` for more.
+    """
+    from dask.dataframe import DataFrame
+
+    return _register_accessor(name, DataFrame)
+
+
+def register_series_accessor(name):
+    """
+    Register a custom accessor on :class:`dask.dataframe.Series`.
+
+    See :func:`pandas.api.extensions.register_series_accessor` for more.
+    """
+    from dask.dataframe import Series
+
+    return _register_accessor(name, Series)
+
+
+def register_index_accessor(name):
+    """
+    Register a custom accessor on :class:`dask.dataframe.Index`.
+
+    See :func:`pandas.api.extensions.register_index_accessor` for more.
+    """
+    from dask.dataframe import Index
+
+    return _register_accessor(name, Index)

--- a/rapids_dask_dependency/patches/dask/dataframe/accessor.py
+++ b/rapids_dask_dependency/patches/dask/dataframe/accessor.py
@@ -2,5 +2,6 @@
 
 from rapids_dask_dependency.importer import VendoredImporter
 
+# Currently vendoring this module due to https://github.com/dask/dask/pull/11035
 _importer = VendoredImporter(__name__)
 load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/dask/dataframe/accessor.py
+++ b/rapids_dask_dependency/patches/dask/dataframe/accessor.py
@@ -2,6 +2,5 @@
 
 from rapids_dask_dependency.importer import VendoredImporter
 
-# TODO: Try to infer the name from the location of the file.
-_importer = VendoredImporter("dask.dataframe.accessor")
+_importer = VendoredImporter(__name__)
 load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/dask/dataframe/accessor.py
+++ b/rapids_dask_dependency/patches/dask/dataframe/accessor.py
@@ -1,7 +1,13 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
+import sys
 
-from rapids_dask_dependency.importer import VendoredImporter
+if sys.version_info >= (3, 11, 9):
+    from dask import __version__
+    from packaging.version import Version
 
-# Currently vendoring this module due to https://github.com/dask/dask/pull/11035
-_importer = VendoredImporter(__name__)
-load_module = _importer.load_module
+    if Version(__version__) < Version("2024.4.1"):
+        from rapids_dask_dependency.importer import VendoredImporter
+
+        # Currently vendoring this module due to https://github.com/dask/dask/pull/11035
+        _importer = VendoredImporter(__name__)
+        load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/dask/dataframe/accessor.py
+++ b/rapids_dask_dependency/patches/dask/dataframe/accessor.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+from rapids_dask_dependency.importer import VendoredImporter
+
+# TODO: Try to infer the name from the location of the file.
+_importer = VendoredImporter("dask.dataframe.accessor")
+load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/distributed/__init__.py
+++ b/rapids_dask_dependency/patches/distributed/__init__.py
@@ -1,10 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
-import importlib
+from rapids_dask_dependency.importer import MonkeyPatchImporter
 
-
-def load_module():
-    mod = importlib.import_module("distributed")
-    mod._rapids_patched = True
-    mod._rapids_patched = True
-    return mod
+_importer = MonkeyPatchImporter("distributed")
+load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/distributed/__init__.py
+++ b/rapids_dask_dependency/patches/distributed/__init__.py
@@ -1,5 +1,9 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
-from .add_patch_attr import add_patch_attr
+import importlib
 
-patches = [add_patch_attr]
+
+def load_module():
+    mod = importlib.import_module("distributed")
+    mod._rapids_patched = True
+    return mod

--- a/rapids_dask_dependency/patches/distributed/__init__.py
+++ b/rapids_dask_dependency/patches/distributed/__init__.py
@@ -2,5 +2,5 @@
 
 from rapids_dask_dependency.importer import MonkeyPatchImporter
 
-_importer = MonkeyPatchImporter("distributed")
+_importer = MonkeyPatchImporter(__name__, lambda _: None)
 load_module = _importer.load_module

--- a/rapids_dask_dependency/patches/distributed/__init__.py
+++ b/rapids_dask_dependency/patches/distributed/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import importlib
-from rapids_dask_dependency.utils import update_spec
 
 
 def load_module():

--- a/rapids_dask_dependency/patches/distributed/__init__.py
+++ b/rapids_dask_dependency/patches/distributed/__init__.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import importlib
+from rapids_dask_dependency.utils import update_spec
 
 
 def load_module():
     mod = importlib.import_module("distributed")
+    mod._rapids_patched = True
     mod._rapids_patched = True
     return mod

--- a/rapids_dask_dependency/patches/distributed/add_patch_attr.py
+++ b/rapids_dask_dependency/patches/distributed/add_patch_attr.py
@@ -1,5 +1,0 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
-
-
-def add_patch_attr(mod):
-    mod._rapids_patched = True

--- a/rapids_dask_dependency/utils.py
+++ b/rapids_dask_dependency/utils.py
@@ -22,3 +22,13 @@ def patch_warning_stacklevel(level):
     warnings.warn = _make_warning_func(level)
     yield
     warnings.warn = original_warn
+
+
+# Note: The Python documentation does not make it clear whether we're guaranteed that
+# spec is not a copy of the original spec, but that is the case for now. We need to
+# assign this because the spec is used to update module attributes after it is
+# initialized by create_module.
+def update_spec(spec, mod):
+    spec.origin = mod.__spec__.origin
+    spec.submodule_search_locations = mod.__spec__.submodule_search_locations
+    return spec

--- a/rapids_dask_dependency/utils.py
+++ b/rapids_dask_dependency/utils.py
@@ -1,19 +1,20 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import warnings
-from functools import lru_cache
 from contextlib import contextmanager
+from functools import lru_cache
 
 original_warn = warnings.warn
 
 
-@lru_cache()
+@lru_cache
 def _make_warning_func(level):
     def _warning_with_increased_stacklevel(
         message, category=None, stacklevel=1, source=None, **kwargs
     ):
         # Patch warnings to have the right stacklevel
         original_warn(message, category, stacklevel + level, source, **kwargs)
+
     return _warning_with_increased_stacklevel
 
 

--- a/rapids_dask_dependency/utils.py
+++ b/rapids_dask_dependency/utils.py
@@ -30,7 +30,7 @@ def patch_warning_stacklevel(level):
 # spec is not a copy of the original spec, but that is the case for now. We need to
 # assign this because the spec is used to update module attributes after it is
 # initialized by create_module.
-def update_spec(spec, mod):
-    spec.origin = mod.__spec__.origin
-    spec.submodule_search_locations = mod.__spec__.submodule_search_locations
+def update_spec(spec, original_spec):
+    spec.origin = original_spec.origin
+    spec.submodule_search_locations = original_spec.submodule_search_locations
     return spec

--- a/rapids_dask_dependency/utils.py
+++ b/rapids_dask_dependency/utils.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import warnings
+from functools import lru_cache
+from contextlib import contextmanager
+
+original_warn = warnings.warn
+
+
+@lru_cache()
+def _make_warning_func(level):
+    def _warning_with_increased_stacklevel(
+        message, category=None, stacklevel=1, source=None, **kwargs
+    ):
+        # Patch warnings to have the right stacklevel
+        original_warn(message, category, stacklevel + level, source, **kwargs)
+    return _warning_with_increased_stacklevel
+
+
+@contextmanager
+def patch_warning_stacklevel(level):
+    warnings.warn = _make_warning_func(level)
+    yield
+    warnings.warn = original_warn

--- a/rapids_dask_dependency/utils.py
+++ b/rapids_dask_dependency/utils.py
@@ -20,9 +20,10 @@ def _make_warning_func(level):
 
 @contextmanager
 def patch_warning_stacklevel(level):
+    previous_warn = warnings.warn
     warnings.warn = _make_warning_func(level)
     yield
-    warnings.warn = original_warn
+    warnings.warn = previous_warn
 
 
 # Note: The Python documentation does not make it clear whether we're guaranteed that


### PR DESCRIPTION
This PR makes a number of significant changes to the patching infrastructure:
1. This PR reorganizes the patching logic to be based on a more principled approach. Rather than maintaining lists of patch functions that are each responsible for filtering modules to apply themselves to, patches are organized in the patches directory in a tree structure matching dask itself. Patches are found and run by importing the same relative paths within the `patches` directory corresponding to a particular dask or distributed module.
2. It adds proper support for patching submodules. Previously the loader was being disabled whenever a real dask module was being imported, but this is problematic because if some dask modules import others they will pre-populate `sys.modules` with the real modules and therefore the loader will never be used for loading a patched version of the submodule.
3. Patches are no longer just functions applied to modules, they are arbitrary functions executed when a module is imported. As a result, a wider range of modifications is possible than was previously allowed. In particular:
4. The more general functions allow the entire module import to be hijacked and redirected to other modules.
5. The new framework is used to vendor a patched version of the accessor.py module in dask, which resolves the issues observed in https://github.com/dask/dask/pull/11035.