### PR TITLE
Pin to `dask-2024.5.1` for the rapids `24.06` release

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -28,10 +28,10 @@ requirements:
     - setuptools
     - conda-verify
   run:
-    - dask >=2024.1.1
-    - dask-core >=2024.1.1
-    - distributed >=2024.1.1
-    - dask-expr >=0.4.0
+    - dask ==2024.5.1
+    - dask-core ==2024.5.1
+    - distributed ==2024.5.1
+    - dask-expr
 
 about:
   home: https://rapids.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ name = "rapids-dask-dependency"
 version = "24.06.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask @ git+https://github.com/dask/dask.git@main",
-    "distributed @ git+https://github.com/dask/distributed.git@main",
-    "dask-expr @ git+https://github.com/dask/dask-expr.git@main",
+    "dask==2024.5.1",
+    "distributed==2024.5.1",
+    "dask-expr",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
This PR is a proposal to pin to `dask-2024.5.1` for the rapids `24.06` release.

cc @pentschev @charlesbluca @quasiben @galipremsagar 