### PR TITLE
Unpin dask and distributed for 24.10 development

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -28,9 +28,9 @@ requirements:
     - setuptools
     - conda-verify
   run:
-    - dask ==2024.7.1
-    - dask-core ==2024.7.1
-    - distributed ==2024.7.1
+    - dask >=2024.7.1
+    - dask-core >=2024.7.1
+    - distributed >=2024.7.1
     - dask-expr
 
 about:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ name = "rapids-dask-dependency"
 version = "24.10.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2024.7.1",
-    "distributed==2024.7.1",
-    "dask-expr",
+    "dask @ git+https://github.com/dask/dask.git@main",
+    "distributed @ git+https://github.com/dask/distributed.git@main",
+    "dask-expr @ git+https://github.com/dask/dask-expr.git@main",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Unpins dask and distributed for 24.10 development.

~**Blocked by https://github.com/rapidsai/build-planning/issues/88** (Dask no longer supports Python 3.9. Therefore, unpinning too early is a "breaking" change).~

Other Blockers:

- [x] https://github.com/rapidsai/cudf/pull/16535
- [x] https://github.com/dask/dask-expr/pull/1122