### PR TITLE
update pre-commit hook versions, use new ruff config format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ exclude: ".*__rdd_patch_.*"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,19 @@ license-files = ["LICENSE"]
 [tool.setuptools.packages.find]
 include = ["rapids_dask_dependency*"]
 
-[tool.ruff]
-lint.select = ["E", "F", "W", "I", "N", "UP"]
-lint.fixable = ["ALL"]
+[tool.ruff.lint]
+select = [
+    # pycodestyle (errors)
+    "E",
+    # isort
+    "I",
+    # pyflakes
+    "F",
+    # pep8-naming
+    "N",
+    # pyupgrade
+    "UP",
+    # pycodestyle (warnings)
+    "W",
+]
+fixable = ["ALL"]


### PR DESCRIPTION
At least a year ago (I'm not sure when precisely), `ruff` broke up the `[ruff]` table in `pyproject.toml` in favor of storing configuration in several more focused tables, like `[tool.ruff.lint]`. Context: https://github.com/rapidsai/rapids-reviser/pull/51/files#r1755430166

This proposes the following:

* using that new format here, to avoid build issues when that deprecation eventually is enforced and becomes an error
* updating all the pre-commit hooks w/ `pre-commit autoupdate`