### PR TITLE
Remove myself as a required reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vyasr @rapidsai/cudf-dask-codeowners
+* @rapidsai/cudf-dask-codeowners


### PR DESCRIPTION
Most PRs to this repo shouldn't specifically require my review as long as some codeowner takes a look. It's mostly the patching functionality that nobody else can currently review as effectively (although hopefully that too changes over time).