### PR TITLE
Pin dask-expr to `1.1.14` for the 24.10 RAPIDS release

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - dask ==2024.9.0
     - dask-core ==2024.9.0
     - distributed ==2024.9.0
-    - dask-expr
+    - dask-expr ==1.1.14
 
 about:
   home: https://rapids.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
     "dask==2024.9.0",
     "distributed==2024.9.0",
-    "dask-expr",
+    "dask-expr==1.1.14",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/rapids-dask-dependency/pull/60

Dask 2024.9.0 does not automatically pin the correct version of dask-expr, so we need to be very specific.