### PR TITLE
Pin Dask to `2024.11.2` for `24.12` RAPIDS release

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -28,10 +28,10 @@ requirements:
     - setuptools
     - conda-verify
   run:
-    - dask >=2024.9.0
-    - dask-core >=2024.9.0
-    - distributed >=2024.9.0
-    - dask-expr >=1.1.14
+    - dask ==2024.11.2
+    - dask-core ==2024.11.2
+    - distributed ==2024.11.2
+    - dask-expr ==1.1.19
 
 about:
   home: https://rapids.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ name = "rapids-dask-dependency"
 version = "24.12.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask @ git+https://github.com/dask/dask.git@main",
-    "distributed @ git+https://github.com/dask/distributed.git@main",
-    "dask-expr @ git+https://github.com/dask/dask-expr.git@main",
+    "dask==2024.11.2",
+    "distributed==2024.11.2",
+    "dask-expr==1.1.19",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Proposal to pin Dask to `2024.11.2` (the latest version) for the `24.12` RAPIDS release.