### PR TITLE
Unpin dask for 25.02 development

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -28,10 +28,10 @@ requirements:
     - setuptools
     - conda-verify
   run:
-    - dask ==2024.11.2
-    - dask-core ==2024.11.2
-    - distributed ==2024.11.2
-    - dask-expr ==1.1.19
+    - dask >=2024.11.2
+    - dask-core >=2024.11.2
+    - distributed >=2024.11.2
+    - dask-expr >=1.1.19
 
 about:
   home: https://rapids.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ name = "rapids-dask-dependency"
 version = "25.02.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2024.11.2",
-    "distributed==2024.11.2",
-    "dask-expr==1.1.19",
+    "dask @ git+https://github.com/dask/dask.git@main",
+    "distributed @ git+https://github.com/dask/distributed.git@main",
+    "dask-expr @ git+https://github.com/dask/dask-expr.git@main",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Unpins the `dask`, `dask-expr`, and `distributed` versions for 25.02 development.

Depends on https://github.com/rapidsai/cudf/pull/17439 (**Update**: Now merged).