### PR TITLE
Unpin dask/distributed for 25.04 development and upstream testing

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -28,10 +28,9 @@ requirements:
     - setuptools
     - conda-verify
   run:
-    - dask ==2024.12.1
-    - dask-core ==2024.12.1
-    - distributed ==2024.12.1
-    - dask-expr ==1.1.21
+    - dask >=2025.1.0
+    - dask-core >=2025.1.0
+    - distributed >=2025.1.0
 
 about:
   home: https://rapids.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ name = "rapids-dask-dependency"
 version = "25.04.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2024.12.1",
-    "distributed==2024.12.1",
-    "dask-expr==1.1.21",
+    "dask @ git+https://github.com/dask/dask.git@main",
+    "distributed @ git+https://github.com/dask/distributed.git@main",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
RAPIDS has been pinned to `2024.12.1` since the `dask/dask-expr` module was migrated into `dask/dask`. This PR removes the `2024.12.1` pin for RAPIDS 25.04 development. We definitely want to merge this as early in the 25.04 development cycle as possible.