### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "dask @ git+https://github.com/dask/dask.git@main",
     "distributed @ git+https://github.com/dask/distributed.git@main",
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 readme = { file = "README.md", content-type = "text/markdown" }
 
 [project.optional-dependencies]


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
