### PR TITLE
Depend on released version of Dask

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -28,9 +28,9 @@ requirements:
     - setuptools
     - conda-verify
   run:
-    - dask >=2025.1.0
-    - dask-core >=2025.1.0
-    - distributed >=2025.1.0
+    - dask ==2025.2.0
+    - dask-core ==2025.2.0
+    - distributed ==2025.2.0
 
 about:
   home: https://rapids.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "25.04.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask>=2025.1.0",
-    "distributed>=2025.1.0",
+    "dask==2025.2.0",
+    "distributed==2025.2.0",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "25.04.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask @ git+https://github.com/dask/dask.git@main",
-    "distributed @ git+https://github.com/dask/distributed.git@main",
+    "dask>=2025.1.0",
+    "distributed>=2025.1.0",
 ]
 license = { text = "Apache 2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
This updates the required version of Dask / distributed to 2025.2.0, rather than `main`.

Paired with the recent changes in dask-upstream-testing, we'll have some coverage for downstream RAPIDS projects against Dask main.

The summary of our version policy is for RAPIDS libraries to depend only on released versions of dask, which is controlled in rapids-dask-dependency. CI runs in repos like `rapidsai/cudf` will pick up the latest version of dask allowed by `rapids-dask-dependency`.

To ensure we catch and address issues between Dask and RAPIDS before, rapids-dask-dependency includes a cron job that creates an environment with RAPIDS nightly and Dask main. It then runs upstream tests from Dask and downstream tests (e.g. cudf_dask) in that environment. Any failures there will be addressed by PRs in the appropriate library.

