### PR TITLE
remove conda-verify dependency

### DIFF
--- a/conda/recipes/rapids-dask-dependency/meta.yaml
+++ b/conda/recipes/rapids-dask-dependency/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - pip
     - python >=3.9
     - setuptools
-    - conda-verify
   run:
     - dask >=2025.1.0
     - dask-core >=2025.1.0


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/150

Proposes removing `host:` dependency on `conda-verify`. See the discussion in https://github.com/rapidsai/rapids-metadata/issues/43 for background.