### PR TITLE
enforce pre-commit checks in CI, add verify-copyright hook

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   pr-builder:
     needs:
+      - checks
       - conda-python-build
       - wheel-build
       - telemetry-setup
@@ -28,6 +29,14 @@ jobs:
         # since other jobs depend on it.
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
+  checks:
+    runs-on: ubuntu-latest
+    needs: telemetry-setup
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: pre-commit/action@v3.0.1
   conda-python-build:
     secrets: inherit
     needs: telemetry-setup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,24 @@ exclude: ".*__rdd_patch_.*"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v0.6.0
+    hooks:
+      - id: verify-copyright
 
 default_language_version:
       python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.6.0
     hooks:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -15,5 +15,5 @@ python -m pip wheel . -w dist -vv --no-deps --disable-pip-version-check
 RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist
 
 # Run tests
-python -m pip install $(ls dist/*.whl)[test]
+python -m pip install "$(echo dist/*.whl)[test]"
 python -m pytest -v tests/

--- a/rapids_dask_dependency/patches/distributed/comm/ucx.py
+++ b/rapids_dask_dependency/patches/distributed/comm/ucx.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
-import sys
 
 from rapids_dask_dependency.loaders import make_vendored_loader
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+
 import contextlib
 import subprocess
 import tempfile
@@ -8,16 +10,18 @@ from multiprocessing import Process
 def run_test_in_subprocess(func):
     def redirect_stdout_stderr(func, stdout, stderr, *args, **kwargs):
         with open(stdout, "w") as stdout_file, open(stderr, "w") as stderr_file:
-            with contextlib.redirect_stdout(stdout_file), contextlib.redirect_stderr(
-                stderr_file
+            with (
+                contextlib.redirect_stdout(stdout_file),
+                contextlib.redirect_stderr(stderr_file),
             ):
                 func(*args, **kwargs)
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        with tempfile.NamedTemporaryFile(
-            mode="w+"
-        ) as stdout, tempfile.NamedTemporaryFile(mode="w+") as stderr:
+        with (
+            tempfile.NamedTemporaryFile(mode="w+") as stdout,
+            tempfile.NamedTemporaryFile(mode="w+") as stderr,
+        ):
             p = Process(
                 target=redirect_stdout_stderr,
                 args=(func, stdout.name, stderr.name, *args),


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Working on #86, I ran `pre-commit run --all-files` locally and was surprised to see some unrelated changes made. It looks like this is because `pre-commit` checks aren't enforced in CI here.

This proposes the following:

* update all pre-commit hooks to their latest versions (`pre-commit autoupdate`)
* add `shellcheck` and `verify-copyright` hooks
* enforce in CI that `pre-commit` must pass

This should slightly improve our confidence in ✅ from CI for this project.