### PR TITLE
Replace `conda-mambabuild` with `conda-build`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -14,7 +14,7 @@ rapids-print-env
 rapids-logger "Begin py build"
 
 version=$(rapids-generate-version)
-RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry build \
   conda/recipes/rapids-dask-dependency
 
 rapids-upload-conda-to-s3 python


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149