### PR TITLE
Moving wheel builds to specified location and uploading build artifacts to Github

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,10 @@ jobs:
       # Package is pure Python and only ever requires one build.
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      wheel-name: rapids-dask-dependency
+      package-type: python
+      pure-wheel: true
+      append-cuda-suffix: false
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,6 +56,10 @@ jobs:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"
+      wheel-name: rapids-dask-dependency
+      package-type: python
+      pure-wheel: true
+      append-cuda-suffix: false
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,16 +6,14 @@ set -euo pipefail
 source rapids-configure-sccache
 source rapids-date-string
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
-
 version=$(rapids-generate-version)
 
 sed -i "s/^version = .*/version = \"${version}\"/g" "pyproject.toml"
 
-python -m pip wheel . -w "${wheel_dir}" -vv --no-deps --disable-pip-version-check
+python -m pip wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -vv --no-deps --disable-pip-version-check
 
-RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 "${wheel_dir}"
+RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
 # Run tests
-python -m pip install "$(echo ${wheel_dir}/*.whl)[test]"
+python -m pip install "$(echo ${RAPIDS_WHEEL_BLD_OUTPUT_DIR}/*.whl)[test]"
 python -m pytest -v tests/

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,14 +6,16 @@ set -euo pipefail
 source rapids-configure-sccache
 source rapids-date-string
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
+
 version=$(rapids-generate-version)
 
 sed -i "s/^version = .*/version = \"${version}\"/g" "pyproject.toml"
 
-python -m pip wheel . -w dist -vv --no-deps --disable-pip-version-check
+python -m pip wheel . -w "${wheel_dir}" -vv --no-deps --disable-pip-version-check
 
 RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist
 
 # Run tests
-python -m pip install "$(echo dist/*.whl)[test]"
+python -m pip install "$(echo ${wheel_dir}/*.whl)[test]"
 python -m pytest -v tests/

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -14,7 +14,7 @@ sed -i "s/^version = .*/version = \"${version}\"/g" "pyproject.toml"
 
 python -m pip wheel . -w "${wheel_dir}" -vv --no-deps --disable-pip-version-check
 
-RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist
+RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 "${wheel_dir}"
 
 # Run tests
 python -m pip install "$(echo ${wheel_dir}/*.whl)[test]"


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

As part of these changes, all wheel builds need to be in a specified temporary directory indicated by the environment variable `RAPIDS_WHEEL_BLD_OUTPUT_DIR` set on the `ci-wheel` Docker image used for building wheels. This lets us upload all wheel artifacts seamlessly to Github Artifacts.