### PR TITLE
Download build artifacts from Github for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
       # Package is pure Python and only ever requires one build.
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
-      wheel-name: rapids-dask-dependency
+      package-name: rapids-dask-dependency
       package-type: python
       pure-wheel: true
       append-cuda-suffix: false
@@ -72,3 +72,4 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: rapids-dask-dependency
+      package-type: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,7 +56,7 @@ jobs:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
       script: "ci/build_wheel.sh"
-      wheel-name: rapids-dask-dependency
+      package-name: rapids-dask-dependency
       package-type: python
       pure-wheel: true
       append-cuda-suffix: false


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts, wherever applicable. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads in the same way as conda downloads.

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 