### PR TITLE
Update dask to 2025.4.1

### DIFF
--- a/conda/recipes/rapids-dask-dependency/recipe.yaml
+++ b/conda/recipes/rapids-dask-dependency/recipe.yaml
@@ -25,9 +25,9 @@ requirements:
     - pip
     - setuptools
   run:
-    - dask ==2025.2.0
-    - dask-core ==2025.2.0
-    - distributed ==2025.2.0
+    - dask ==2025.4.1
+    - dask-core ==2025.4.1
+    - distributed ==2025.4.1
 
 tests:
   - script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "25.06.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2025.2.0",
-    "distributed==2025.2.0",
+    "dask==2025.4.1",
+    "distributed==2025.4.1",
 ]
 license = { text = "Apache-2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
For the next rapids release (25.06) I'd like to target Dask==2025.4.1.

Currently, the only known failures with dask main are at https://github.com/rapidsai/dask-upstream-testing/issues/44, which should be fixed by https://github.com/rapidsai/cuml/pull/6614. My rough plan is

1. Get that cuml PR merged.
2. Confirm a successful run against dask main
3. Confirm a successful run against dask==2025.4.1 (using https://github.com/rapidsai/dask-upstream-testing/pull/45, hopefully; hardcoding the branch temporaily if not)
4. Monitor CI for downstream libraries to confirm that dask==2025.4.1 is picked up and CI passes.

Closes https://github.com/rapidsai/cudf/issues/18122