### PR TITLE
Quote head_rev in conda recipes

### DIFF
--- a/conda/recipes/rapids-dask-dependency/recipe.yaml
+++ b/conda/recipes/rapids-dask-dependency/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
 
 package:
   name: rapids-dask-dependency


### PR DESCRIPTION
This quotes `head_rev` to ensure that commits with leading zeros in the git SHA include those zeros in the output package name.

xref: https://github.com/rapidsai/build-planning/issues/176
