### PR TITLE
Bump to dask==2025.5.0

### DIFF
--- a/conda/recipes/rapids-dask-dependency/recipe.yaml
+++ b/conda/recipes/rapids-dask-dependency/recipe.yaml
@@ -25,9 +25,9 @@ requirements:
     - pip
     - setuptools
   run:
-    - dask ==2025.4.1
-    - dask-core ==2025.4.1
-    - distributed ==2025.4.1
+    - dask ==2025.5.0
+    - dask-core ==2025.5.0
+    - distributed ==2025.5.0
 
 tests:
   - script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "25.06.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2025.4.1",
-    "distributed==2025.4.1",
+    "dask==2025.5.0",
+    "distributed==2025.5.0",
 ]
 license = { text = "Apache-2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
As noted in https://github.com/rapidsai/dask-upstream-testing/issues/49, dask-upstream-testing wasn't actually pinned to 2024.4.1 thanks to the [overrides](https://github.com/rapidsai/dask-upstream-testing/blob/main/requirements/overrides.txt). We were actually still using dask main, which had some fixes for at least regressions that are causing cuml tests to fail (e.g. https://github.com/rapidsai/cuml/actions/runs/15050986368/job/42307128102?pr=6737#step:9:41248).

This bumps to 2025.5.0, which contains those fixes.