### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       # Package is pure Python and only ever requires one build.
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,6 +46,7 @@ jobs:
       # Package is pure Python and only ever requires one build.
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      script: ci/build_python.sh
   wheel-build:
     secrets: inherit
     needs: telemetry-setup

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 source rapids-configure-sccache
 source rapids-date-string
+source rapids-init-pip
 
 version=$(rapids-generate-version)
 


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* confirmed that `rapids-configure-conda-channels` is not used in any builds scripts using `rattler-build`