### PR TITLE
Pin importlib-metadata to <8.7

### DIFF
--- a/conda/recipes/rapids-dask-dependency/recipe.yaml
+++ b/conda/recipes/rapids-dask-dependency/recipe.yaml
@@ -28,6 +28,9 @@ requirements:
     - dask ==2025.5.0
     - dask-core ==2025.5.0
     - distributed ==2025.5.0
+    # conda-forge has a bad build of importlib-metadata 8.7. Pinning to earlier for now
+    # to unblock CI, will revert once upstream is fixed.
+    - importlib-metadata <8.7
 
 tests:
   - script:


### PR DESCRIPTION
Conda-forge has a bad build of importlib-metadata 8.7. Pinning to an earlier version for now to unblock CI, can revert once upstream is fixed.