### PR TITLE
WIP: stop uploading packages to downloads.rapids.ai

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -28,5 +28,3 @@ rattler-build build --recipe conda/recipes/rapids-dask-dependency \
 # remove build_cache directory to avoid uploading the entire source tree
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
-
-rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -13,8 +13,6 @@ sed -i "s/^version = .*/version = \"${version}\"/g" "pyproject.toml"
 
 python -m pip wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -vv --no-deps --disable-pip-version-check
 
-RAPIDS_PY_WHEEL_NAME="rapids-dask-dependency" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
-
 # Run tests
 python -m pip install "$(echo ${RAPIDS_WHEEL_BLD_OUTPUT_DIR}/*.whl)[test]"
 python -m pytest -v tests/


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/181

* removes all uploads of conda packages and wheels to `downloads.rapids.ai`

## Notes for Reviewers

### How I identified changes

Looked for uses of the relevant `gha-tools` tools, as well as documentation about `downloads.rapids.ai`, being on the NVIDIA VPN, using S3, etc. like this:

```shell
git grep -i -E 's3|upload|downloads\.rapids|vpn'
```

### How I tested this

See "How I tested this" on https://github.com/rapidsai/shared-workflows/pull/364