### PR TITLE
add CI and packaging codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,14 @@
+# default if no other rules below are matched
 * @rapidsai/cudf-dask-codeowners
+
+# CI code owners
+/.github/                 @rapidsai/ci-codeowners
+/ci/                      @rapidsai/ci-codeowners
+
+# packaging codeowners
+/conda/                   @rapidsai/packaging-codeowners
+dependencies.yaml         @rapidsai/packaging-codeowners
+*.pth                     @rapidsai/packaging-codeowners
+pyproject.toml            @rapidsai/packaging-codeowners
+/.pre-commit-config.yaml  @rapidsai/packaging-codeowners
+setup.py                  @rapidsai/packaging-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.6.0
+    rev: v0.7.0
     hooks:
       - id: verify-copyright
 


### PR DESCRIPTION
Adds `ci-codeowners` and `packaging-codeowners` rules to `CODEOWNERS`, to more closely match review and approval practices with the rest of RAPIDS.

## Notes for Reviewers

### Shouldn't we use the `rapidsai/pre-commit-hooks` hook to enforce these conventions?

I don't think it's appropriate here. Many things it expects to exist by default in this repo don't.

A patch like this:

```diff
diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
index 23c3c45..4c8a737 100644
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,8 @@ repos:
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.7.0
     hooks:
+      - id: verify-codeowners
+        args: [--fix, --project-prefix=rapids-dask-dependency]
       - id: verify-copyright
 
 default_language_version:
```

results in changes like this:

```diff
+/build.sh @rapidsai/packaging-codeowners
+/.devcontainer/ @rapidsai/packaging-codeowners
+cpp/ @rapidsai/rapids-dask-dependency-cpp-codeowners
+python/ @rapidsai/rapids-dask-dependency-python-codeowners
+CMakeLists.txt @rapidsai/rapids-dask-dependency-cmake-codeowners
+**/cmake/ @rapidsai/rapids-dask-dependency-cmake-codeowners
+*.cmake @rapidsai/rapids-dask-dependency-cmake-codeowners
```

All referring to files that don't exist in this this repo.