### PR TITLE
Add UCXX proxy backend

### DIFF
--- a/rapids_dask_dependency/patches/distributed/comm/__rdd_patch_ucx.py
+++ b/rapids_dask_dependency/patches/distributed/comm/__rdd_patch_ucx.py
@@ -562,7 +562,6 @@ class UCXBackend(Backend):
         return UCXConnector()
 
     def get_listener(self, loc, handle_comm, deserialize, **connection_args):
-        print("UCXBackend.get_listener", flush=True)
         warnings.warn(
             "you have requested protocol='ucx', which now defaults to UCXX but "
             "the package distributed-ucxx is not installed. In the current version "
@@ -660,8 +659,6 @@ except ImportError:
 finally:
     backends["ucx"] = _rewrite_ucxx_backend()()
 backends["ucx-old"] = UCXBackendOld()
-print(f"{backends['ucx']=}", flush=True)
-print(f"{backends['ucx-old']=}", flush=True)
 
 
 def _prepare_ucx_config():

--- a/rapids_dask_dependency/patches/distributed/comm/__rdd_patch_ucx.py
+++ b/rapids_dask_dependency/patches/distributed/comm/__rdd_patch_ucx.py
@@ -646,18 +646,7 @@ def _rewrite_ucxx_backend():
     except ImportError:
         return UCXBackend
 
-try:
-    # It's necessary to `try`/`except` `import distributed_ucxx` first, then in
-    # the `finally` block `from distributed_ucxx.ucxx import UCXXBackend` should
-    # succeed if distributed-ucxx is installed. This requirement is probably due
-    # to distributed-ucxx registering `backends["ucxx"]` as an entry point.
-    # This entire block is temporary (along with this entire file) until UCXX
-    # becomes the default and only backend and UCX-Py is ultimately archived.
-    import distributed_ucxx
-except ImportError:
-    pass
-finally:
-    backends["ucx"] = _rewrite_ucxx_backend()()
+backends["ucx"] = _rewrite_ucxx_backend()()
 backends["ucx-old"] = UCXBackendOld()
 
 


### PR DESCRIPTION
Add a proxy communication backend to enable UCXX when `protocol="ucx"`, overriding UCX-Py. Additionally, provide warnings when UCXX is not installed letting the user know UCX-Py is EOL and will be removed, as well as a proper fallback `protocol="ucx-old"` to continue using UCX-Py while it's not completely archived.