### PR TITLE
Pin to Dask/Distributed 2025.9.1

### DIFF
--- a/conda/recipes/rapids-dask-dependency/recipe.yaml
+++ b/conda/recipes/rapids-dask-dependency/recipe.yaml
@@ -25,9 +25,9 @@ requirements:
     - pip
     - setuptools
   run:
-    - dask ==2025.7.0
-    - dask-core ==2025.7.0
-    - distributed ==2025.7.0
+    - dask ==2025.9.1
+    - dask-core ==2025.9.1
+    - distributed ==2025.9.1
 
 tests:
   - script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ name = "rapids-dask-dependency"
 version = "25.10.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
-    "dask==2025.7.0",
-    "distributed==2025.7.0",
+    "dask==2025.9.1",
+    "distributed==2025.9.1",
 ]
 license = { text = "Apache-2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Upgrading to 2025.9.1 should allow us to remove the [UCX backend patching from rapids-dask-dependency](https://github.com/rapidsai/rapids-dask-dependency/blob/branch-25.10/rapids_dask_dependency/patches/distributed/comm/__rdd_patch_ucx.py).