### PR TITLE
Update to 26.08

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 
 [project]
 name = "rapids-dask-dependency"
-version = "26.06.00a0"
+version = "26.08.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
     "dask>=2026.1.1,<2026.1.2",


### PR DESCRIPTION
This PR updates the repository to version 26.08.

This is part of the 26.06 release burndown process.
