### PR TITLE
Update to 26.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 
 [project]
 name = "rapids-dask-dependency"
-version = "26.08.00a0"
+version = "26.10.00a0"
 description = "Dask and Distributed version pinning for RAPIDS"
 dependencies = [
     "dask>=2026.3.0,<2026.3.1",


### PR DESCRIPTION
This PR updates the repository to version 26.10.

This is part of the 26.08 release burndown process.
